### PR TITLE
Test and robustify

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,7 +5,7 @@ all_passed=true
 for test in t*.sh
 do
 	echo ==================== Run Test $test
-	./$test || all_passed=false
+	./"$test" || all_passed=false
 done
 echo ==================== 
 echo Result:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cd test
+all_passed=true
+for test in t*.sh
+do
+	echo ==================== Run Test $test
+	./$test || all_passed=false
+done
+echo ==================== 
+echo Result:
+
+if $all_passed
+then
+	echo Pass
+else
+	echo FAIL
+fi
+
+# return status to caller
+$all_passed

--- a/spotfind.sh
+++ b/spotfind.sh
@@ -5,11 +5,11 @@
 ######
 
 param1=$1
-if [ -z $1 ]; then 
+if [ -z "$1" ]; then 
 	param1="?"
 fi
 
-if [ $param1 = "?" ] || [ $param1 = "--help" ] || [ $param1 = "-h" ]; then
+if [ "$param1" = "?" ] || [ "$param1" = "--help" ] || [ "$param1" = "-h" ]; then
 	echo "usage: spotfind [-fpc] [restrict_search_to_folder] file_wildcards
 	Default usage searches for a file with the name containing the first parameter
 	
@@ -38,8 +38,8 @@ if [ $param1 = "?" ] || [ $param1 = "--help" ] || [ $param1 = "-h" ]; then
 	   a result, where as Terminal would.
 "
 else
-	if [ $1 = "-c" ] || [ $1 = "--configure" ]; then
-		if [ -z $2 ]; then
+	if [ "$1" = "-c" ] || [ "$1" = "--configure" ]; then
+		if [ -z "$2" ]; then
 			echo "Adding /Library folder to the Spotlight search indexes, please wait..."
 			mdimport /Library
 			echo "Adding /usr folder to the Spotlight search indexes, please wait..."
@@ -53,15 +53,15 @@ else
 		
 		If you would like to expand the types of files that Spotlight indexes (such as text within source code files), then go to http://www.macosxtips.co.uk/index_files/terminal-commands-for-improving-spotlight.html and follow the instructions under 'Make Spotlight index source code'
 		If you need to rebuild the indexes, execute the command: sudo mdutil -E /"
-	elif [ $1 = "-f" ] || [ $1 = "--folder" ]; then
+	elif [ "$1" = "-f" ] || [ "$1" = "--folder" ]; then
 		mdfind "kMDItemKind == 'Folder' && kMDItemDisplayName == '$2'c"
-	elif [ $1 = "-p" ] || [ $1 = "--phrase" ]; then
+	elif [ "$1" = "-p" ] || [ "$1" = "--phrase" ]; then
 		if [ -z $3 ]; then
-			mdfind $2 
+			mdfind "$2" 
 		else
-			mdfind -onlyin $2 $3
+			mdfind -onlyin "$2" "$3"
 		fi
-	elif [ -z $2 ]; then
+	elif [ -z "$2" ]; then
 		mdfind "kMDItemDisplayName == '$1'c"
 	else
 		mdfind -onlyin $1 "kMDItemDisplayName == '$2'c"

--- a/test/mdfind
+++ b/test/mdfind
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo RAN_MDFIND "$@"

--- a/test/t1.sh
+++ b/test/t1.sh
@@ -3,11 +3,13 @@
 export PATH=.:"$PATH"
 
 result=false
-if stdout=$(../spotfind.sh "thing" 2>&1)
+if stdout="$(../spotfind.sh "thing" 2>&1)"
 then
 	if [[ "$stdout" == "RAN_MDFIND kMDItemDisplayName == 'thing'c" ]]
 	then
 		result=true
+	else
+		echo "$stdout"
 	fi
 fi
 
@@ -20,5 +22,3 @@ fi
 
 # return the test status as exit status
 $result
-
-

--- a/test/t1.sh
+++ b/test/t1.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+export PATH=.:"$PATH"
+
+result=false
+if stdout=$(../spotfind.sh "thing" 2>&1)
+then
+	if [[ "$stdout" == "RAN_MDFIND kMDItemDisplayName == 'thing'c" ]]
+	then
+		result=true
+	fi
+fi
+
+if $result
+then
+	echo "Pass"
+else
+	echo "FAIL"
+fi
+
+# return the test status as exit status
+$result
+
+

--- a/test/t2.sh
+++ b/test/t2.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export PATH=.:"$PATH"
+
+result=false
+if stdout=$(../spotfind.sh "thing with space" 2>&1 )
+then
+    echo "$stdout"
+	if [[ "$stdout" == "RAN_MDFIND kMDItemDisplayName == 'thing with space'c" ]]
+	then
+		result=true
+	fi
+fi
+
+if $result
+then
+	echo "Pass"
+else
+	echo "FAIL"
+fi
+
+# return the test status as exit status
+$result
+
+

--- a/test/t2.sh
+++ b/test/t2.sh
@@ -3,12 +3,13 @@
 export PATH=.:"$PATH"
 
 result=false
-if stdout=$(../spotfind.sh "thing with space" 2>&1 )
+if stdout="$(../spotfind.sh "thing with space" 2>&1 )"
 then
-    echo "$stdout"
-	if [[ "$stdout" == "RAN_MDFIND kMDItemDisplayName == 'thing with space'c" ]]
+    if [[ "$stdout" == "RAN_MDFIND kMDItemDisplayName == 'thing with space'c" ]]
 	then
 		result=true
+	else
+		echo "$stdout"
 	fi
 fi
 
@@ -21,5 +22,3 @@ fi
 
 # return the test status as exit status
 $result
-
-


### PR DESCRIPTION
Hi,

Thanks for this cool script. I noticed a bunch of bash errors when you give it an argument with spaces in, e.g. 

```
$ spotfind.sh "Disk Utility" 
spotfind.sh: line 8: [: too many arguments
spotfind.sh: line 12: [: too many arguments
spotfind.sh: line 12: [: too many arguments
spotfind.sh: line 12: [: too many arguments
spotfind.sh: line 41: [: too many arguments
spotfind.sh: line 41: [: too many arguments
spotfind.sh: line 56: [: too many arguments
spotfind.sh: line 56: [: too many arguments
spotfind.sh: line 58: [: too many arguments
spotfind.sh: line 58: [: too many arguments
```

...so I added a bunch of quote marks in the if statements.

I also added a couple of tests. t2.sh reproduces the bug.

Hope you enjoy!

Steve
